### PR TITLE
fix: PostCard 컴포넌트에서 data 없을 시 null 반환 처리

### DIFF
--- a/src/components/card/PostCard.tsx
+++ b/src/components/card/PostCard.tsx
@@ -22,6 +22,8 @@ export default function PostCard({
   data: PostCardType;
   project?: boolean;
 }) {
+  if (!data) return null;
+
   const { id, tag, title, description } = data;
 
   return (


### PR DESCRIPTION
PostCard 컴포넌트에서 data가 undefined 또는 null인 경우를 처리하지 않아 발생할 수 있는 에러를 방지하기 위해 방어 코드를 추가했습니다.