### PR TITLE
fix: 다크 모드 초기 렌더링 및 테마 변경 로직 수정

### DIFF
--- a/src/components/darkMode/DarkModeSync.tsx
+++ b/src/components/darkMode/DarkModeSync.tsx
@@ -18,17 +18,27 @@ export function DarkModeSync() {
     (state: RootState) => state.isDarkMode.isDarkMode,
   );
   const isInitialized = useRef(false);
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    if (isInitialized.current) return;
+
     if (!resolvedTheme) return;
 
     const isDark = resolvedTheme === THEME.DARK;
     dispatch(setDarkMode(isDark));
     isInitialized.current = true;
-  }, []);
+  }, [resolvedTheme, dispatch]);
 
   useEffect(() => {
     if (!isInitialized.current || !resolvedTheme) return;
+
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
 
     const isDark = resolvedTheme === THEME.DARK;
     const themeChanged = isDark !== isDarkMode;
@@ -40,6 +50,11 @@ export function DarkModeSync() {
 
   useEffect(() => {
     if (!isInitialized.current) return;
+
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
 
     const newTheme = isDarkMode ? THEME.DARK : THEME.LIGHT;
     setTheme(newTheme);

--- a/src/components/darkMode/DarkModeToggleButton.tsx
+++ b/src/components/darkMode/DarkModeToggleButton.tsx
@@ -10,7 +10,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '@/store/store';
 import { setDarkMode } from '@/store/slices/darkModeSlice';
 import { useTheme } from 'next-themes';
 import { MoonIcon, SunIcon, ComputerIcon } from 'lucide-react';
@@ -33,11 +34,14 @@ export default function DarkModeToggleButton() {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     setMounted(true);
   }, []);
 
-  const isSystemDarkMode = () =>
-    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isSystemDarkMode = () => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  };
 
   const handleThemeChange = (newTheme: string) => {
     setTheme(newTheme);
@@ -66,6 +70,14 @@ export default function DarkModeToggleButton() {
       <SunIcon className={ICON_SIZES.DEFAULT} />
     );
   };
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" className="w-10 cursor-pointer">
+        <SunIcon className={ICON_SIZES.DEFAULT} />
+      </Button>
+    );
+  }
 
   return (
     <DropdownMenu>


### PR DESCRIPTION
- DarkModeSync 컴포넌트에 초기 렌더링 시 불필요한 테마 변경 방지 로직 추가
- DarkModeToggleButton에서 `mounted` 상태 기반 초기 렌더링 처리 및 window 체크 로직 개선
- resolvedTheme 및 dispatch를 useEffect 의존성 배열에 추가 (정확한 업데이트를 위해)